### PR TITLE
Fix YUV data_length not being cleared after buffer consumption

### DIFF
--- a/src/asic.c
+++ b/src/asic.c
@@ -341,10 +341,12 @@ void pvr_dma_transfer( )
     uint32_t rcount;
 
     while( count ) {
-        uint32_t chunksize = (count < 8192) ? count : 8192;
+        uint32_t chunksize = (count < sizeof(data)) ? count : sizeof(data);
         rcount = DMAC_get_buffer( 2, data, chunksize );
         pvr2_dma_write( destaddr, data, rcount );
-        destaddr += rcount;
+        if( destaddr & 0x01000000 ) {
+            destaddr += rcount;
+        }
         count -= rcount;
         if( rcount != chunksize ) {
             WARN( "PVR received %08X bytes from DMA, expected %08X", rcount, chunksize );

--- a/src/pvr2/yuv.c
+++ b/src/pvr2/yuv.c
@@ -160,8 +160,8 @@ void pvr2_yuv_write( unsigned char *data, uint32_t length )
 
     if( length != 0 ) { /* Save the left over data */
         memcpy( pvr2_yuv_state.data, data, length );
-        pvr2_yuv_state.data_length = length;
     }
+    pvr2_yuv_state.data_length = length;
 }
 
 void pvr2_yuv_init( uint32_t target )


### PR DESCRIPTION
Also fix PVR2 DMA target address to only increment when writing to VRAM