### PR TITLE
Fix compilation & crashes on macOS

### DIFF
--- a/src/drivers/video_osx.m
+++ b/src/drivers/video_osx.m
@@ -59,6 +59,7 @@ static NSView *video_view = NULL;
 @interface LxdreamOSXView : LxdreamVideoView
 {
     int flagsMask[MAX_MASK_KEYCODE];
+    double scaleFactor;
 }
 @end
 
@@ -87,6 +88,20 @@ static NSView *video_view = NULL;
         for( i=0; i<MAX_MASK_KEYCODE; i++ ) {
             flagsMask[i] = 0;
         }
+
+        // Get scale factor for retina display
+        scaleFactor = 1.0;
+        if ([[NSScreen mainScreen] respondsToSelector:@selector(backingScaleFactor)]) {
+            NSArray *screens = [NSScreen screens];
+            NSUInteger screenCount = screens.count;
+            for (int i = 0; i < screenCount; i++) {
+                float s = [screens[i] backingScaleFactor];
+                if (s > scaleFactor) {
+                    scaleFactor = s;
+                }
+            }
+        }
+
         return self;
     }
     return nil;
@@ -120,7 +135,7 @@ static NSView *video_view = NULL;
 {
     NSSize size = [self frame].size;
     if( video_width != size.width || video_height != size.height ) {
-        gl_set_video_size(size.width, size.height, 0);
+        gl_set_video_size(size.width * scaleFactor, size.height * scaleFactor, 0);
         video_nsgl_update();
     }
     pvr2_draw_frame();

--- a/src/drivers/video_osx.m
+++ b/src/drivers/video_osx.m
@@ -59,7 +59,6 @@ static NSView *video_view = NULL;
 @interface LxdreamOSXView : LxdreamVideoView
 {
     int flagsMask[MAX_MASK_KEYCODE];
-    double scaleFactor;
 }
 @end
 
@@ -87,19 +86,6 @@ static NSView *video_view = NULL;
         isGrabbed = NO;
         for( i=0; i<MAX_MASK_KEYCODE; i++ ) {
             flagsMask[i] = 0;
-        }
-
-        // Get scale factor for retina display
-        scaleFactor = 1.0;
-        if ([[NSScreen mainScreen] respondsToSelector:@selector(backingScaleFactor)]) {
-            NSArray *screens = [NSScreen screens];
-            NSUInteger screenCount = screens.count;
-            for (int i = 0; i < screenCount; i++) {
-                float s = [screens[i] backingScaleFactor];
-                if (s > scaleFactor) {
-                    scaleFactor = s;
-                }
-            }
         }
 
         return self;
@@ -133,9 +119,9 @@ static NSView *video_view = NULL;
 //--------------------------------------------------------------------
 - (void)drawRect: (NSRect) rect
 {
-    NSSize size = [self frame].size;
+    NSSize size = [self convertSizeToBacking: [self frame].size];
     if( video_width != size.width || video_height != size.height ) {
-        gl_set_video_size(size.width * scaleFactor, size.height * scaleFactor, 0);
+        gl_set_video_size(size.width, size.height, 0);
         video_nsgl_update();
     }
     pvr2_draw_frame();

--- a/src/sh4/mmu.c
+++ b/src/sh4/mmu.c
@@ -332,7 +332,7 @@ MMIO_REGION_WRITE_FN( MMU, reg, val )
  */ 
 static void mmu_utlb_1k_init()
 {
-    mmu_utlb_1k_pages = (struct utlb_1k_entry *)mmap( NULL, sizeof(struct utlb_1k_entry) * (UTLB_ENTRY_COUNT + 1),
+    mmu_utlb_1k_pages = (struct utlb_1k_entry *)mmap( NULL, sizeof(struct utlb_1k_entry) * UTLB_ENTRY_COUNT,
         PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_PRIVATE, -1, 0 );
 
     int i;

--- a/src/sh4/sh4x86.in
+++ b/src/sh4/sh4x86.in
@@ -36,6 +36,7 @@
 #include "xlat/x86/x86op.h"
 #include "xlat/xlatdasm.h"
 #include "clock.h"
+#include <sys/mman.h>
 
 #define DEFAULT_BACKPATCH_SIZE 4096
 
@@ -115,7 +116,7 @@ struct sh4_x86_state {
 
 static struct sh4_x86_state sh4_x86;
 
-static uint8_t sh4_entry_stub[128];
+static uint8_t *sh4_entry_stub;
 typedef FASTCALL void (*entry_point_t)(void *);
 entry_point_t sh4_translate_enter;
 
@@ -149,7 +150,9 @@ void sh4_translate_set_address_space( struct mem_region_fn **priv, struct mem_re
 
 void sh4_translate_write_entry_stub(void)
 {
-	mem_unprotect(sh4_entry_stub, sizeof(sh4_entry_stub));
+    sh4_entry_stub = (struct utlb_page_entry *)mmap( NULL, sizeof(uint8_t) * 128,
+        PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_PRIVATE, -1, 0 );
+
 	xlat_output = sh4_entry_stub;
 	PUSH_r32(REG_EBP);
 	MOVP_immptr_rptr( ((uint8_t *)&sh4r) + 128, REG_EBP );

--- a/src/sh4/sh4x86.in
+++ b/src/sh4/sh4x86.in
@@ -150,7 +150,7 @@ void sh4_translate_set_address_space( struct mem_region_fn **priv, struct mem_re
 
 void sh4_translate_write_entry_stub(void)
 {
-    sh4_entry_stub = (struct utlb_page_entry *)mmap( NULL, sizeof(uint8_t) * 128,
+    sh4_entry_stub = (uint8_t *)mmap( NULL, sizeof(uint8_t) * 128,
         PROT_READ|PROT_WRITE|PROT_EXEC, MAP_ANON|MAP_PRIVATE, -1, 0 );
 
 	xlat_output = sh4_entry_stub;

--- a/src/tools/actparse.c
+++ b/src/tools/actparse.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <sys/stat.h>
 #include <glib.h>

--- a/src/tools/insparse.c
+++ b/src/tools/insparse.c
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <strings.h>
 #include <string.h>
 #include <ctype.h>
 #include "tools/gendec.h"

--- a/src/tools/mdparse.c
+++ b/src/tools/mdparse.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>


### PR DESCRIPTION
Hi there,

Here are couple of fixes related with compiling lxdream on macOS and also fixed crash related with using mprotect syscall since macOS Catalina. 
And also in this pull request you can find fix with rendering on retina display for macOS